### PR TITLE
Add salt and hash to Account password

### DIFF
--- a/src/main/java/seedu/address/commons/util/XmlUtil.java
+++ b/src/main/java/seedu/address/commons/util/XmlUtil.java
@@ -12,7 +12,6 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.account.Account;
 import seedu.address.model.account.AccountList;
 import seedu.address.storage.XmlSerializableAccountList;
 
@@ -76,17 +75,17 @@ public class XmlUtil {
     /**
      * Update the user with the {@code currentAccount} to the new password.
      * @param file The valid xml file containing the account list stored.
-     * @param currentAccount The associated Account of which the password is to be changed.
+     * @param username The associated username of which the password is to be changed.
      * @param newPassword The new password to change to
      * @throws IllegalValueException Thrown if duplicated account was found in the account list.
      * @throws JAXBException Thrown if there is an error during converting the data
      * into xml and writing to the file.
      * @throws FileNotFoundException Thrown if the account list file cannot be found.
      */
-    public static void updatePasswordInFile(Path file, Account currentAccount, String newPassword)
+    public static void updatePasswordInFile(Path file, String username, String newPassword)
             throws IllegalValueException, JAXBException, FileNotFoundException {
         requireNonNull(file);
-        requireNonNull(currentAccount);
+        requireNonNull(username);
         requireNonNull(newPassword);
 
         if (!Files.exists(file)) {
@@ -101,7 +100,8 @@ public class XmlUtil {
 
         // update password
         AccountList accountList = currentList.toModelType();
-        accountList.updatePassword(currentAccount, newPassword);
+
+        accountList.updatePassword(username, newPassword);
         XmlSerializableAccountList newUpdatedList = new XmlSerializableAccountList(accountList);
 
         // overwrite old file

--- a/src/main/java/seedu/address/logic/commands/RegisterAccountCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RegisterAccountCommand.java
@@ -40,6 +40,8 @@ public class RegisterAccountCommand extends Command {
             + "or r/readonlyuser\" for role.";
     public static final String MESSAGE_FAILURE_FILENOTFOUND = "Failed to find the file to save account to.";
     public static final String MESSAGE_FAILURE_DUPLICATE = "Username is taken. Please try again with another username.";
+    public static final String MESSAGE_INVALIDROLE = "Role should contains only"
+            + "\"superuser\" or \"readonlyuser\".";
 
     private Account account;
     private Path accountListPath;
@@ -86,5 +88,12 @@ public class RegisterAccountCommand extends Command {
             }
             throw new CommandException(MESSAGE_FAILURE);
         }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RegisterAccountCommand // instanceof handles nulls
+                && account.equals(((RegisterAccountCommand) other).account));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/LoginCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LoginCommandParser.java
@@ -7,7 +7,6 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.account.Account;
 
 /**
  * Parses input arguments
@@ -34,8 +33,7 @@ public class LoginCommandParser implements Parser<LoginCommand> {
         Optional<String> password = argMultimap.getValue(LoginCommand.PREFIX_PASSWORD);
 
         if (username.isPresent() && password.isPresent()) {
-            Account account = new Account(username.get(), password.get());
-            return new LoginCommand(account);
+            return new LoginCommand(username.get(), password.get());
         }
 
         throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LoginCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/RegisterAccountCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RegisterAccountCommandParser.java
@@ -46,7 +46,7 @@ public class RegisterAccountCommandParser implements Parser<RegisterAccountComma
                 Account account = new Account(username.get(), password.get(), Role.READ_ONLY_USER);
                 return new RegisterAccountCommand(account);
             } else {
-                throw new ParseException("Role should contains only \"superuser\" or \"readonlyuser\".");
+                throw new ParseException(RegisterAccountCommand.MESSAGE_INVALIDROLE);
             }
         }
 

--- a/src/main/java/seedu/address/logic/security/PasswordAuthentication.java
+++ b/src/main/java/seedu/address/logic/security/PasswordAuthentication.java
@@ -32,7 +32,7 @@ public final class PasswordAuthentication {
      */
     public static final int DEFAULT_COST = 16;
 
-    private static final String ALGORITHM = "PBKDF2WithHmacSHA1";
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA512";
 
     private static final int SIZE = 128;
 
@@ -55,6 +55,11 @@ public final class PasswordAuthentication {
         int dummy = iterations(cost); /* Validate cost */
         this.cost = cost;
         this.random = new SecureRandom();
+    }
+
+    public static String getHashedPasswordFromPlainText(String plainText) {
+        PasswordAuthentication passwordAuthentication = new PasswordAuthentication();
+        return passwordAuthentication.hash(plainText.toCharArray());
     }
 
     /**
@@ -89,9 +94,7 @@ public final class PasswordAuthentication {
      * <p>Passwords should be stored in a {@code char[]} so that it can be filled
      * with zeros after use instead of lingering on the heap and elsewhere.
      *
-     * @deprecated Use {@link #hash(char[])} instead
      */
-    @Deprecated
     public String hash(String password) {
         return hash(password.toCharArray());
     }

--- a/src/main/java/seedu/address/logic/security/PasswordAuthentication.java
+++ b/src/main/java/seedu/address/logic/security/PasswordAuthentication.java
@@ -1,0 +1,146 @@
+package seedu.address.logic.security;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+/**
+ * Hash passwords for storage, and test passwords against password tokens.
+ * <p>
+ * Instances of this class can be used concurrently by multiple threads.
+ *
+ * @author erickson
+ * @see <a href="http://stackoverflow.com/a/2861125/3474">StackOverflow</a>
+ */
+public final class PasswordAuthentication {
+
+    /**
+     * Each token produced by this class uses this identifier as a prefix.
+     */
+    public static final String ID = "$31$";
+
+    /**
+     * The minimum recommended cost, used by default
+     */
+    public static final int DEFAULT_COST = 16;
+
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA1";
+
+    private static final int SIZE = 128;
+
+    private static final Pattern layout = Pattern.compile("\\$31\\$(\\d\\d?)\\$(.{43})");
+
+    private final SecureRandom random;
+
+    private final int cost;
+
+    public PasswordAuthentication() {
+        this(DEFAULT_COST);
+    }
+
+    /**
+     * Create a password manager with a specified cost
+     *
+     * @param cost the exponential computational cost of hashing a password, 0 to 30
+     */
+    public PasswordAuthentication(int cost) {
+        int dummy = iterations(cost); /* Validate cost */
+        this.cost = cost;
+        this.random = new SecureRandom();
+    }
+
+    /**
+     * Conduct an iteration.
+     */
+    private static int iterations(int cost) {
+        if ((cost < 0) || (cost > 30)) {
+            throw new IllegalArgumentException("cost: " + cost);
+        }
+        return 1 << cost;
+    }
+
+    /**
+     * Hash a password for storage.
+     *
+     * @return a secure authentication token to be stored for later authentication
+     */
+    public String hash(char[] password) {
+        byte[] salt = new byte[SIZE / 8];
+        random.nextBytes(salt);
+        byte[] dk = pbkdf2(password, salt, 1 << cost);
+        byte[] hash = new byte[salt.length + dk.length];
+        System.arraycopy(salt, 0, hash, 0, salt.length);
+        System.arraycopy(dk, 0, hash, salt.length, dk.length);
+        Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+        return ID + cost + '$' + enc.encodeToString(hash);
+    }
+
+    /**
+     * Hash a password in an immutable {@code String}.
+     * <p>
+     * <p>Passwords should be stored in a {@code char[]} so that it can be filled
+     * with zeros after use instead of lingering on the heap and elsewhere.
+     *
+     * @deprecated Use {@link #hash(char[])} instead
+     */
+    @Deprecated
+    public String hash(String password) {
+        return hash(password.toCharArray());
+    }
+
+    /**
+     * Authenticate with a password and a stored password token.
+     *
+     * @return true if the password and token match
+     */
+    public boolean authenticate(char[] password, String token) {
+        Matcher m = layout.matcher(token);
+        if (!m.matches()) {
+            throw new IllegalArgumentException("Invalid token format");
+        }
+        int iterations = iterations(Integer.parseInt(m.group(1)));
+        byte[] hash = Base64.getUrlDecoder().decode(m.group(2));
+        byte[] salt = Arrays.copyOfRange(hash, 0, SIZE / 8);
+        byte[] check = pbkdf2(password, salt, iterations);
+        int zero = 0;
+        for (int idx = 0; idx < check.length; ++idx) {
+            zero |= hash[salt.length + idx] ^ check[idx];
+        }
+        return zero == 0;
+    }
+
+    /**
+     * Authenticate with a password in an immutable {@code String} and a stored
+     * password token.
+     *
+     * @see #hash(String)
+     * @deprecated Use {@link #authenticate(char[], String)} instead.
+     */
+    @Deprecated
+    public boolean authenticate(String password, String token) {
+        return authenticate(password.toCharArray(), token);
+    }
+
+    /**
+     * Use the pbkdf2 algorithm provided by java
+     */
+    private static byte[] pbkdf2(char[] password, byte[] salt, int iterations) {
+        KeySpec spec = new PBEKeySpec(password, salt, iterations, SIZE);
+        try {
+            SecretKeyFactory f = SecretKeyFactory.getInstance(ALGORITHM);
+            return f.generateSecret(spec).getEncoded();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("Missing algorithm: " + ALGORITHM, ex);
+        } catch (InvalidKeySpecException ex) {
+            throw new IllegalStateException("Invalid SecretKeyFactory", ex);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/security/PasswordAuthentication.java
+++ b/src/main/java/seedu/address/logic/security/PasswordAuthentication.java
@@ -121,18 +121,6 @@ public final class PasswordAuthentication {
     }
 
     /**
-     * Authenticate with a password in an immutable {@code String} and a stored
-     * password token.
-     *
-     * @see #hash(String)
-     * @deprecated Use {@link #authenticate(char[], String)} instead.
-     */
-    @Deprecated
-    public boolean authenticate(String password, String token) {
-        return authenticate(password.toCharArray(), token);
-    }
-
-    /**
      * Use the pbkdf2 algorithm provided by java
      */
     private static byte[] pbkdf2(char[] password, byte[] salt, int iterations) {

--- a/src/main/java/seedu/address/model/account/Account.java
+++ b/src/main/java/seedu/address/model/account/Account.java
@@ -1,5 +1,7 @@
 package seedu.address.model.account;
 
+import seedu.address.logic.security.PasswordAuthentication;
+
 /**
  * Account class represents a single Account that comprises of a username,
  * password, and role associated with an account.
@@ -39,6 +41,10 @@ public class Account {
 
     public Role getRole() {
         return role;
+    }
+
+    public void transformToHashedAccount() {
+        this.password = PasswordAuthentication.getHashedPasswordFromPlainText(password);
     }
 
     /**

--- a/src/main/java/seedu/address/model/account/AccountList.java
+++ b/src/main/java/seedu/address/model/account/AccountList.java
@@ -1,8 +1,11 @@
 package seedu.address.model.account;
+
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import seedu.address.logic.security.PasswordAuthentication;
 
 /**
  * AccountList represents the entire list of accounts that were created
@@ -43,13 +46,13 @@ public class AccountList {
 
     /**
      * Update the user associated with the {@code currentAccount} to the given password.
-     * @param currentAccount The user to update the password.
-     * @param newPassword The password to update the account
+     * @param username The username to update the account.
+     * @param plainTextPassword The password to update the account
      */
-    public void updatePassword(Account currentAccount, String newPassword) {
+    public void updatePassword(String username, String plainTextPassword) {
         for (Account account : accountList) {
-            if (account.equals(currentAccount)) {
-                account.setPassword(newPassword);
+            if (account.getUserName().equalsIgnoreCase(username)) {
+                account.setPassword(plainTextPassword);
             }
         }
     }
@@ -74,6 +77,25 @@ public class AccountList {
     public boolean hasAccount(Account account) {
         requireNonNull(account);
         return indexOfAccount(account) != -1;
+    }
+
+    /**
+     * Return true if the account list contains the username, and the password provided
+     * is also correct.
+     * @param username The username of the account
+     * @param plainTextPassword The plaintext password of the account
+     * @return True if the username and password matches an existing account in the account list.
+     */
+    public boolean hasUsernameAndPassword(String username, String plainTextPassword) {
+        PasswordAuthentication passwordAuthentication = new PasswordAuthentication();
+
+        for (Account account : accountList) {
+            if (account.getUserName().equalsIgnoreCase(username)
+                    && passwordAuthentication.authenticate(plainTextPassword.toCharArray(), account.getPassword())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/AccountStorage.java
+++ b/src/main/java/seedu/address/storage/AccountStorage.java
@@ -60,5 +60,5 @@ public interface AccountStorage {
      */
     void populateRootAccountIfMissing(Account account);
 
-    void updateAccountPassword(Account currentAccount, String newPassword) throws FileNotFoundException;
+    void updateAccountPassword(String username, String newPassword) throws FileNotFoundException;
 }

--- a/src/main/java/seedu/address/storage/XmlAccountStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAccountStorage.java
@@ -79,6 +79,7 @@ public class XmlAccountStorage implements AccountStorage {
         try {
             AccountList accountList = getAccountList();
 
+            account.transformToHashedAccount();
             accountList.getList().add(account);
             XmlFileStorage.saveAccountDataToFile(filePath, new XmlSerializableAccountList(accountList));
         } catch (DataConversionException e) {
@@ -94,6 +95,7 @@ public class XmlAccountStorage implements AccountStorage {
             try {
                 FileUtil.createFile(accountListPath);
                 AccountList accountList = new AccountList();
+                account.transformToHashedAccount();
                 accountList.addAccount(account);
                 XmlFileStorage.saveAccountDataToFile(accountListPath, new XmlSerializableAccountList(accountList));
             } catch (IOException e) {
@@ -103,9 +105,9 @@ public class XmlAccountStorage implements AccountStorage {
     }
 
     @Override
-    public void updateAccountPassword(Account currentAccount, String newPassword) throws FileNotFoundException {
+    public void updateAccountPassword(String username, String newPassword) throws FileNotFoundException {
         try {
-            XmlUtil.updatePasswordInFile(accountListPath, currentAccount, newPassword);
+            XmlUtil.updatePasswordInFile(accountListPath, username, newPassword);
         } catch (JAXBException | IllegalValueException e) {
             throw new AssertionError("Unexpected exception " + e.getMessage(), e);
         }

--- a/src/main/java/seedu/address/storage/XmlAccountStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAccountStorage.java
@@ -83,7 +83,7 @@ public class XmlAccountStorage implements AccountStorage {
             accountList.getList().add(account);
             XmlFileStorage.saveAccountDataToFile(filePath, new XmlSerializableAccountList(accountList));
         } catch (DataConversionException e) {
-            logger.info("Illegal values found in " + filePath + ": " + e.getMessage());
+            throw new AssertionError("Illegal values found in " + filePath + ": " + e.getMessage());
         }
     }
 
@@ -100,6 +100,7 @@ public class XmlAccountStorage implements AccountStorage {
                 XmlFileStorage.saveAccountDataToFile(accountListPath, new XmlSerializableAccountList(accountList));
             } catch (IOException e) {
                 logger.info("Account: Unable to create file or directory: " + accountListPath + e.getMessage());
+                throw new AssertionError("File not found" + e.getMessage(), e);
             }
         }
     }

--- a/src/test/data/Account/accountlist.xml
+++ b/src/test/data/Account/accountlist.xml
@@ -2,17 +2,17 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$xJlS90cjUkRwZ1h1w5XcZUxVdclXV5u1GXBjQnXPZLg</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/LoginCommandTest/accountlist_withrootonly.xml
+++ b/src/test/data/LoginCommandTest/accountlist_withrootonly.xml
@@ -2,7 +2,7 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/LoginCommandTest/accountlist_withselfregisteredaccount.xml
+++ b/src/test/data/LoginCommandTest/accountlist_withselfregisteredaccount.xml
@@ -2,17 +2,17 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/RegisterAccountCommandTest/accountlist_withrootonly.xml
+++ b/src/test/data/RegisterAccountCommandTest/accountlist_withrootonly.xml
@@ -2,12 +2,12 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$4nTBeIWH2wHpYXGbyy4EX_r_hJ8Cx0NQDZ-2wNsjssE</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>username123</username>
-        <password>password456</password>
+        <password>$31$16$gSv0IHBWtPvTLuwELQ_2Bx4KGjae6cb3Gui3WZDz-sI</password>
         <role>SUPER_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/RegisterAccountCommandTest/invalidaccountlist_wrongstructure.xml
+++ b/src/test/data/RegisterAccountCommandTest/invalidaccountlist_wrongstructure.xml
@@ -2,12 +2,12 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <!-- Invalid account with wrong structure. No username in this case. -->
     <accounts>
-        <password>rootPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/SystemTest/rootaccount_accountlist.xml
+++ b/src/test/data/SystemTest/rootaccount_accountlist.xml
@@ -2,7 +2,7 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlAccountStorageTest/InvalidAndValidUsernameAccountList.xml
+++ b/src/test/data/XmlAccountStorageTest/InvalidAndValidUsernameAccountList.xml
@@ -3,13 +3,13 @@
     <!-- This account is valid -->
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <!-- This account is invalid as username is empty -->
     <accounts>
         <username></username>
-        <password>password</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlAccountStorageTest/InvalidUsernameAccountList.xml
+++ b/src/test/data/XmlAccountStorageTest/InvalidUsernameAccountList.xml
@@ -3,7 +3,7 @@
     <!-- This account is invalid as username is empty -->
     <accounts>
         <username></username>
-        <password>password</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlAccountStorageTest/accountlist.xml
+++ b/src/test/data/XmlAccountStorageTest/accountlist.xml
@@ -2,17 +2,17 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$QpshkU1Gdlk9QvEe7Ufeel1eJjoISdGkGkSX-FlTC1g</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$jr84Ep341cjbStbsgz14BJVShqeTxXShO7zrorecCok</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$x9j5aJHibWf08dVOlTTijolCa2fxYN9J7-jXS3oizks</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlAccountStorageTest/accountlistToChangePassword.xml
+++ b/src/test/data/XmlAccountStorageTest/accountlistToChangePassword.xml
@@ -2,17 +2,17 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$7BirkXymljTjRnasZkwbQDVxGjJTDCO6gqMWecDQZHI</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlSerializableAccountListTest/duplicateAccount_AccountList.xml
+++ b/src/test/data/XmlSerializableAccountListTest/duplicateAccount_AccountList.xml
@@ -2,18 +2,18 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <!-- Duplicated account with same username -->
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
-        <role>READ_ONLY_USER</role>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
+        <role>SUPER_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlSerializableAccountListTest/invalidAccount_AccountList.xml
+++ b/src/test/data/XmlSerializableAccountListTest/invalidAccount_AccountList.xml
@@ -2,13 +2,13 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <!-- Invalid account with empty username -->
     <accounts>
         <username></username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
    </accountmanager>

--- a/src/test/data/XmlSerializableAccountListTest/typicalAccount_AccountList.xml
+++ b/src/test/data/XmlSerializableAccountListTest/typicalAccount_AccountList.xml
@@ -2,17 +2,17 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlUtilTest/accountlist.xml
+++ b/src/test/data/XmlUtilTest/accountlist.xml
@@ -2,17 +2,17 @@
 <accountmanager>
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$lQRytOr6jb_hXz53BPZu7vrrRsdhNmn0BhtE7CTnpgY</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlUtilTest/accountlistEmptyPassword.xml
+++ b/src/test/data/XmlUtilTest/accountlistEmptyPassword.xml
@@ -8,12 +8,13 @@
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>someN3wP@ssw0rd</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>
+

--- a/src/test/data/XmlUtilTest/accountlistEmptyRole.xml
+++ b/src/test/data/XmlUtilTest/accountlistEmptyRole.xml
@@ -3,16 +3,16 @@
     <!-- Illegal account: no role -->
     <accounts>
         <username>rootUser</username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>

--- a/src/test/data/XmlUtilTest/accountlistEmptyUsername.xml
+++ b/src/test/data/XmlUtilTest/accountlistEmptyUsername.xml
@@ -3,17 +3,18 @@
     <!-- Illegal account: empty username -->
     <accounts>
         <username></username>
-        <password>rootPassword</password>
+        <password>$31$16$nboNXKlrmU8_FEMLMWJ7g08DE2Pj0smRiR6rWxKjMqY</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>simun</username>
-        <password>@myPassword</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>SUPER_USER</role>
     </accounts>
     <accounts>
         <username>whiterose</username>
-        <password>someN3wP@ssw0rd</password>
+        <password>$31$16$vWaAyBBNfZny3HMcqw3Sa-v36U4cgT8SeatiW-PvkSs</password>
         <role>READ_ONLY_USER</role>
     </accounts>
 </accountmanager>
+

--- a/src/test/java/seedu/address/logic/commands/EditPasswordCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPasswordCommandTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
-import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/src/test/java/seedu/address/logic/commands/EditPasswordCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPasswordCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -22,6 +23,7 @@ public class EditPasswordCommandTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data",
             "Account");
     private static final Path VALID_ACCOUNTLIST = TEST_DATA_FOLDER.resolve("accountlist.xml");
+    private static final Path INVALID_FILEPATH = TEST_DATA_FOLDER.resolve("someinvalidpath.xml");
     private static final String OLD_PASSWORD = "@myPassword";
     private static final String NEW_PASSWORD = "SomeNewP@Ssw0rd";
 
@@ -69,6 +71,14 @@ public class EditPasswordCommandTest {
                 OLD_PASSWORD, VALID_ACCOUNTLIST);
         assertCommandFailure(editPasswordCommand, model, commandHistory,
                 EditPasswordCommand.MESSAGE_FAILURE_SAMEPASSWORD);
+    }
+
+    @Test
+    public void execute_fileNotFoundException() {
+        EditPasswordCommand editPasswordCommand = new EditPasswordCommand(OLD_PASSWORD,
+                NEW_PASSWORD, INVALID_FILEPATH);
+        assertCommandFailure(editPasswordCommand, model, commandHistory,
+                EditPasswordCommand.MESSAGE_FAILURE_FILENOTFOUND);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -24,6 +24,9 @@ public class LoginCommandTest {
     private static final Path ACCOUNTLIST_WITHROOT = TEST_DATA_FOLDER.resolve("accountlist_withrootonly.xml");
     private static final Path ACCOUNTLIST_WITSELFREGISTEREDACCOUNT = TEST_DATA_FOLDER
             .resolve("accountlist_withselfregisteredaccount.xml");
+
+    private static final String USERNAME = "rootUser";
+    private static final String PASSWORD = "rootPassword";
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -32,40 +35,56 @@ public class LoginCommandTest {
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
-    public void constructor_nullAccount_throwsNullPointerException() {
+    public void constructor_nullUsername_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        new LoginCommand(null);
+        new LoginCommand(null, PASSWORD);
     }
 
     @Test
-    public void constructor2_nullAccount_throwsNullPointerException() {
+    public void constructor_nullPassword_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        new LoginCommand(null, ACCOUNTLIST_WITHROOT);
+        new LoginCommand(USERNAME, null);
+    }
+
+    @Test
+    public void constructor2_nullUsername_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new LoginCommand(null, PASSWORD, ACCOUNTLIST_WITHROOT);
+    }
+
+    @Test
+    public void constructor2_nullPasswrod_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new LoginCommand(USERNAME, null, ACCOUNTLIST_WITHROOT);
     }
 
     @Test
     public void execute_rootAccountSucceed() {
-        LoginCommand loginCommand = new LoginCommand(TypicalAccount.ROOTACCOUNT, ACCOUNTLIST_WITHROOT);
+        LoginCommand loginCommand = new LoginCommand(USERNAME, PASSWORD, ACCOUNTLIST_WITHROOT);
         assertCommandSuccess(loginCommand, model, commandHistory, LoginCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_userRegisteredAccountSucceed() {
-        LoginCommand loginCommandSimun = new LoginCommand(TypicalAccount.SIMUN, ACCOUNTLIST_WITSELFREGISTEREDACCOUNT);
+        Account simun = TypicalAccount.SIMUN;
+        LoginCommand loginCommandSimun = new LoginCommand(simun.getUserName(), simun.getPassword(),
+                ACCOUNTLIST_WITSELFREGISTEREDACCOUNT);
         assertCommandSuccess(loginCommandSimun, model, commandHistory, LoginCommand.MESSAGE_SUCCESS, expectedModel);
 
-        LoginCommand loginCommandRose = new LoginCommand(TypicalAccount.ROSE, ACCOUNTLIST_WITSELFREGISTEREDACCOUNT);
+        Account rose = TypicalAccount.ROSE;
+        LoginCommand loginCommandRose = new LoginCommand(rose.getUserName(), rose.getPassword(),
+                ACCOUNTLIST_WITSELFREGISTEREDACCOUNT);
         assertCommandSuccess(loginCommandRose, model, commandHistory, LoginCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_usernameOrPasswordWrong() {
-        Account usernameWrong = new Account("usernameWrong", "rootPassword", Role.SUPER_USER);
-        LoginCommand loginWrongUsername = new LoginCommand(usernameWrong, ACCOUNTLIST_WITHROOT);
+        String usernameWrong = "wrongUserName";
+        LoginCommand loginWrongUsername = new LoginCommand(usernameWrong, PASSWORD, ACCOUNTLIST_WITHROOT);
         assertCommandFailure(loginWrongUsername, model, commandHistory, LoginCommand.MESSAGE_FAILURE);
 
-        Account passwordWrong = new Account("rootUser", "rootPasswordWrong", Role.SUPER_USER);
-        LoginCommand loginWrongPassword = new LoginCommand(passwordWrong, ACCOUNTLIST_WITHROOT);
+        String passwordWrong = "wrongPassword";
+        LoginCommand loginWrongPassword = new LoginCommand(USERNAME, passwordWrong, ACCOUNTLIST_WITHROOT);
         assertCommandFailure(loginWrongPassword, model, commandHistory, LoginCommand.MESSAGE_FAILURE);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -14,7 +14,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.account.Account;
-import seedu.address.testutil.TypicalAccount;
+import seedu.address.model.account.Role;
 
 public class LoginCommandTest {
 
@@ -65,12 +65,12 @@ public class LoginCommandTest {
 
     @Test
     public void execute_userRegisteredAccountSucceed() {
-        Account simun = TypicalAccount.SIMUN;
+        Account simun = new Account("simun", "@myPassword", Role.SUPER_USER);
         LoginCommand loginCommandSimun = new LoginCommand(simun.getUserName(), simun.getPassword(),
                 ACCOUNTLIST_WITSELFREGISTEREDACCOUNT);
         assertCommandSuccess(loginCommandSimun, model, commandHistory, LoginCommand.MESSAGE_SUCCESS, expectedModel);
 
-        Account rose = TypicalAccount.ROSE;
+        Account rose = new Account("whiterose", "@myPassword", Role.SUPER_USER);
         LoginCommand loginCommandRose = new LoginCommand(rose.getUserName(), rose.getPassword(),
                 ACCOUNTLIST_WITSELFREGISTEREDACCOUNT);
         assertCommandSuccess(loginCommandRose, model, commandHistory, LoginCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -14,7 +14,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.account.Account;
-import seedu.address.model.account.Role;
 import seedu.address.testutil.TypicalAccount;
 
 public class LoginCommandTest {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -17,7 +17,6 @@ import org.junit.rules.ExpectedException;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditPasswordCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,11 +18,15 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditPasswordCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.LoginCommand;
+import seedu.address.logic.commands.LogoutCommand;
 import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.RegisterAccountCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,6 +39,8 @@ import seedu.address.testutil.EditContactDescriptorBuilder;
 import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
+    private static final String BLANK_SPACE = " ";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -51,6 +57,48 @@ public class AddressBookParserTest {
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_registeraccount() throws Exception {
+        assertTrue(parser.parseCommand(RegisterAccountCommand.COMMAND_WORD + BLANK_SPACE
+                + RegisterAccountCommand.PREFIX_USERNNAME + "user" + BLANK_SPACE
+                + RegisterAccountCommand.PREFIX_PASSWORD + "pass" + BLANK_SPACE
+                + RegisterAccountCommand.PREFIX_ROLE + "superuser") instanceof RegisterAccountCommand);
+    }
+
+    @Test
+    public void parseCommand_logoutCommand() throws Exception {
+        assertTrue(parser.parseCommand(LogoutCommand.COMMAND_WORD) instanceof LogoutCommand);
+    }
+
+    @Test
+    public void parseCommand_editPasswordCommand() throws Exception {
+        assertTrue(parser.parseCommand(EditPasswordCommand.COMMAND_WORD + BLANK_SPACE
+                + EditPasswordCommand.PREFIX_OLDPASSWORD + "k2" + BLANK_SPACE
+                + EditPasswordCommand.PREFIX_NEWPASSWORD + "new" + BLANK_SPACE) instanceof EditPasswordCommand);
+    }
+
+    @Test
+    public void parseCommand_exitCommand_afterLoggedIn() throws Exception {
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_exitCommand_beforeLoggedIn() throws Exception {
+        assertTrue(parser.parseCommandBeforeLoggedIn(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_loginCommand() throws Exception {
+        assertTrue(parser.parseCommandBeforeLoggedIn(LoginCommand.COMMAND_WORD + BLANK_SPACE
+                + LoginCommand.PREFIX_USERNNAME + "rootUser" + BLANK_SPACE
+                + LoginCommand.PREFIX_PASSWORD + "rootPassword" + BLANK_SPACE) instanceof LoginCommand);
+    }
+
+    @Test
+    public void parseCommand_helpCommand_beforeLoggedIn() throws Exception {
+        assertTrue(parser.parseCommandBeforeLoggedIn(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/LoginCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LoginCommandParserTest.java
@@ -17,7 +17,7 @@ public class LoginCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        LoginCommand loginCommand = new LoginCommand(rootAccount);
+        LoginCommand loginCommand = new LoginCommand(rootAccount.getUserName(), rootAccount.getPassword());
         assertParseSuccess(parser, BLANK_SPACE + LoginCommand.PREFIX_USERNNAME.getPrefix()
                 + rootAccount.getUserName() + BLANK_SPACE + LoginCommand.PREFIX_PASSWORD.getPrefix()
                 + rootAccount.getPassword(), loginCommand);

--- a/src/test/java/seedu/address/logic/parser/RegisterAccountCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RegisterAccountCommandParserTest.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.RegisterAccountCommand;
+import seedu.address.model.account.Account;
+import seedu.address.model.account.Role;
+import seedu.address.testutil.TypicalAccount;
+
+public class RegisterAccountCommandParserTest {
+    private static final String BLANK_SPACE = " ";
+    private static final Account rootAccount = TypicalAccount.ROOTACCOUNT;
+    private RegisterAccountCommandParser parser = new RegisterAccountCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_successSuperUser() {
+        RegisterAccountCommand registerAccountCommand = new RegisterAccountCommand(new Account("username",
+                "password", Role.SUPER_USER));
+        assertParseSuccess(parser, BLANK_SPACE + RegisterAccountCommand.PREFIX_USERNNAME.getPrefix()
+                + "username" + BLANK_SPACE + RegisterAccountCommand.PREFIX_PASSWORD.getPrefix()
+                + "password" + BLANK_SPACE + RegisterAccountCommand.PREFIX_ROLE + "superuser",
+                registerAccountCommand);
+    }
+
+    @Test
+    public void parse_allFieldsPresent_successReadOnlyUser() {
+        RegisterAccountCommand registerAccountCommand = new RegisterAccountCommand(new Account("username",
+                "password", Role.READ_ONLY_USER));
+        assertParseSuccess(parser, BLANK_SPACE + RegisterAccountCommand.PREFIX_USERNNAME.getPrefix()
+                        + "username" + BLANK_SPACE + RegisterAccountCommand.PREFIX_PASSWORD.getPrefix()
+                        + "password" + BLANK_SPACE + RegisterAccountCommand.PREFIX_ROLE + "readonlyuser",
+                registerAccountCommand);
+    }
+
+    @Test
+    public void parse_invalidWrong_parseException() {
+        String expectedMessage = RegisterAccountCommand.MESSAGE_INVALIDROLE;
+        // missing username prefix
+        assertParseFailure(parser, BLANK_SPACE + RegisterAccountCommand.PREFIX_USERNNAME.getPrefix()
+                        + "username" + BLANK_SPACE + RegisterAccountCommand.PREFIX_PASSWORD.getPrefix()
+                        + "password" + BLANK_SPACE + RegisterAccountCommand.PREFIX_ROLE + "invalidRole",
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, RegisterAccountCommand.MESSAGE_USAGE);
+
+        // missing username prefix
+        assertParseFailure(parser, BLANK_SPACE + RegisterAccountCommand.PREFIX_PASSWORD.getPrefix()
+                + rootAccount.getPassword() + BLANK_SPACE + RegisterAccountCommand.PREFIX_ROLE + "superuser",
+                expectedMessage);
+
+        // missing password prefix
+        assertParseFailure(parser, BLANK_SPACE + RegisterAccountCommand.PREFIX_USERNNAME.getPrefix()
+                + rootAccount.getUserName() + BLANK_SPACE + RegisterAccountCommand.PREFIX_ROLE
+                + "superuser", expectedMessage);
+
+        // missing role prefix
+        assertParseFailure(parser, BLANK_SPACE + RegisterAccountCommand.PREFIX_USERNNAME.getPrefix()
+                + rootAccount.getUserName() + BLANK_SPACE + RegisterAccountCommand.PREFIX_USERNNAME.getPrefix()
+                + rootAccount.getUserName(), expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/security/PasswordAuthenticationTest.java
+++ b/src/test/java/seedu/address/logic/security/PasswordAuthenticationTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PasswordAuthenticationTest {
+    private static final PasswordAuthentication passwordAuthentication = new PasswordAuthentication();
+    private static final String plainTextPassword = "plaintext";
+
+    @Test
+    public void hashIsWorking_success() {
+        String hashed = passwordAuthentication.hash(plainTextPassword.toCharArray());
+        // hashed and plaintext are different
+        assertFalse(hashed.equals(plainTextPassword));
+        // plaintext is the correct password for the hash
+        assertTrue(passwordAuthentication.authenticate(plainTextPassword.toCharArray(), hashed));
+        String wrongPassword = "wrongPassword";
+        // wrongPassword is not the correct password for the hash
+        assertFalse(passwordAuthentication.authenticate(wrongPassword.toCharArray(), hashed));
+    }
+
+    @Test
+    public void staticMethodWorking() {
+        String hashed = PasswordAuthentication.getHashedPasswordFromPlainText(plainTextPassword);
+        assertTrue(passwordAuthentication.authenticate(plainTextPassword.toCharArray(), hashed));
+    }
+}

--- a/src/test/java/seedu/address/logic/security/PasswordAuthenticationTest.java
+++ b/src/test/java/seedu/address/logic/security/PasswordAuthenticationTest.java
@@ -3,11 +3,16 @@ package seedu.address.logic.security;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class PasswordAuthenticationTest {
     private static final PasswordAuthentication passwordAuthentication = new PasswordAuthentication();
     private static final String plainTextPassword = "plaintext";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void hashIsWorking_success() {
@@ -25,5 +30,17 @@ public class PasswordAuthenticationTest {
     public void staticMethodWorking() {
         String hashed = PasswordAuthentication.getHashedPasswordFromPlainText(plainTextPassword);
         assertTrue(passwordAuthentication.authenticate(plainTextPassword.toCharArray(), hashed));
+    }
+
+    @Test
+    public void iteration_tooHigh_fail() {
+        thrown.expect(IllegalArgumentException.class);
+        new PasswordAuthentication(31);
+    }
+
+    @Test
+    public void iteration_negative_fail() {
+        thrown.expect(IllegalArgumentException.class);
+        new PasswordAuthentication(-1);
     }
 }

--- a/src/test/java/seedu/address/model/account/AccountListTest.java
+++ b/src/test/java/seedu/address/model/account/AccountListTest.java
@@ -118,4 +118,14 @@ public class AccountListTest {
         assertFalse(list.get(0).getPassword().equals(newPassword));
         assertTrue(list.get(0).getPassword().equals(newPassword2));
     }
+
+    @Test
+    public void equals() {
+        AccountList accountList = new AccountList();
+        accountList.addAccount(new Account("user", "password"));
+
+        AccountList accountList2 = new AccountList();
+        accountList2.addAccount(new Account("user", "password"));
+        assertTrue(accountList.equals(accountList2));
+    }
 }

--- a/src/test/java/seedu/address/model/account/AccountListTest.java
+++ b/src/test/java/seedu/address/model/account/AccountListTest.java
@@ -110,11 +110,11 @@ public class AccountListTest {
         List<Account> list = accountList.getList();
         assertTrue(list.get(0).getPassword().equals(oldPassword));
 
-        accountList.updatePassword(account, newPassword);
+        accountList.updatePassword(account.getUserName(), newPassword);
         assertFalse(list.get(0).getPassword().equals(oldPassword));
         assertTrue(list.get(0).getPassword().equals(newPassword));
 
-        accountList.updatePassword(account, newPassword2);
+        accountList.updatePassword(account.getUserName(), newPassword2);
         assertFalse(list.get(0).getPassword().equals(newPassword));
         assertTrue(list.get(0).getPassword().equals(newPassword2));
     }

--- a/src/test/java/seedu/address/model/account/AccountTest.java
+++ b/src/test/java/seedu/address/model/account/AccountTest.java
@@ -54,8 +54,8 @@ public class AccountTest {
 
     @Test
     public void equals() {
-        Account account1 = new Account("testusername", "testP@ssw0rD", Role.SUPER_USER);
-        Account account2 = new Account("testusername", "testP@ssw0rD", Role.SUPER_USER);
+        Account account1 = new Account("testusername", "testP@ssw0rD");
+        Account account2 = new Account("testusername", "testP@ssw0rD");
         assertEquals(account1, account2);
         Account account3 = new Account("TESTUserNaMe", "testP@ssw0rD", Role.SUPER_USER);
         assertEquals(account2, account3);

--- a/src/test/java/seedu/address/model/account/AccountTest.java
+++ b/src/test/java/seedu/address/model/account/AccountTest.java
@@ -43,6 +43,16 @@ public class AccountTest {
     }
 
     @Test
+    public void transformToHashedAccountSuccess() {
+        String plainTextPassword = "plainTextPassword";
+        Account account = new Account("Username", plainTextPassword, Role.SUPER_USER);
+        assertTrue(account.getPassword().equals(plainTextPassword));
+
+        account.transformToHashedAccount();
+        assertFalse(account.getPassword().equals(plainTextPassword));
+    }
+
+    @Test
     public void equals() {
         Account account1 = new Account("testusername", "testP@ssw0rD", Role.SUPER_USER);
         Account account2 = new Account("testusername", "testP@ssw0rD", Role.SUPER_USER);

--- a/src/test/java/seedu/address/storage/XmlAccountStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAccountStorageTest.java
@@ -16,13 +16,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.logic.security.PasswordAuthentication;
 import seedu.address.model.account.Account;
 import seedu.address.model.account.AccountList;
 import seedu.address.model.account.Role;
 import seedu.address.testutil.TypicalAccount;
-
 
 public class XmlAccountStorageTest {
 
@@ -32,6 +32,8 @@ public class XmlAccountStorageTest {
             "XmlAccountStorageTest", "accountlist.xml");
     private static final Path TEST_ACCOUNTLIST_TOCHANGEPASSWORD = Paths.get("src", "test", "data",
             "XmlAccountStorageTest", "accountlistToChangePassword.xml");
+    private static final Path INVALID_ACCOUNTDATA = Paths.get("src", "test", "data",
+            "XmlAccountStorageTest", "InvalidUsernameAccountList.xml");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -95,6 +97,13 @@ public class XmlAccountStorageTest {
         } catch (IOException | DataConversionException e) {
             throw new RuntimeException();
         }
+    }
+
+    @Test
+    public void saveAccount_catchDataConversionException() throws Exception {
+        thrown.expect(AssertionError.class);
+        AccountStorage accountStorage = new XmlAccountStorage(INVALID_ACCOUNTDATA);
+        accountStorage.saveAccount(TypicalAccount.ROSE);
     }
 
     @Test
@@ -163,6 +172,13 @@ public class XmlAccountStorageTest {
         } catch (DataConversionException | IOException e) {
             throw new AssertionError("There should not be an error saving to the file.", e);
         }
+    }
+
+    @Test
+    public void updateAccountPassword_catchIllegalValueException() throws Exception {
+        thrown.expect(AssertionError.class);
+        AccountStorage accountStorage = new XmlAccountStorage(INVALID_ACCOUNTDATA);
+        accountStorage.updateAccountPassword("username", "password");
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/XmlAccountStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAccountStorageTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.PasswordUtil.assertPasswordCorrect;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.util.FileUtil;
+import seedu.address.logic.security.PasswordAuthentication;
 import seedu.address.model.account.Account;
 import seedu.address.model.account.AccountList;
 import seedu.address.model.account.Role;
@@ -172,24 +174,23 @@ public class XmlAccountStorageTest {
         int indexOfRose = 2;
 
         try {
+            PasswordAuthentication passwordAuthentication = new PasswordAuthentication();
             AccountList accountList = accountStorage.getAccountList();
             List<Account> list = accountList.getList();
-            assertTrue(list.get(indexOfRose).getPassword().equals(oldPassword));
+            assertPasswordCorrect(oldPassword, list.get(indexOfRose).getPassword());
 
             // change to new password
-            accountStorage.updateAccountPassword(account, newPassword);
+            accountStorage.updateAccountPassword(account.getUserName(), passwordAuthentication.hash(newPassword));
             accountList = accountStorage.getAccountList();
             list = accountList.getList();
-            assertFalse(list.get(indexOfRose).getPassword().equals(oldPassword));
-            assertTrue(list.get(indexOfRose).getPassword().equals(newPassword));
+            assertPasswordCorrect(newPassword, list.get(indexOfRose).getPassword());
 
             // change back to old password
             Account newAccount = new Account("whiterose", newPassword, Role.READ_ONLY_USER);
-            accountStorage.updateAccountPassword(newAccount, oldPassword);
+            accountStorage.updateAccountPassword(newAccount.getUserName(), passwordAuthentication.hash(oldPassword));
             accountList = accountStorage.getAccountList();
             list = accountList.getList();
-            assertFalse(list.get(indexOfRose).getPassword().equals(newPassword));
-            assertTrue(list.get(indexOfRose).getPassword().equals(oldPassword));
+            assertPasswordCorrect(oldPassword, list.get(indexOfRose).getPassword());
         } catch (DataConversionException | IOException e) {
             throw new AssertionError("File should exist and this line should not be called.", e);
         }

--- a/src/test/java/seedu/address/storage/XmlAccountStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAccountStorageTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.DataConversionException;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.logic.security.PasswordAuthentication;
 import seedu.address.model.account.Account;

--- a/src/test/java/seedu/address/storage/XmlSerializableAccountListTest.java
+++ b/src/test/java/seedu/address/storage/XmlSerializableAccountListTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.testutil.TypicalAccount.ROOTACCOUNT;
 import static seedu.address.testutil.TypicalAccount.ROSE;
 import static seedu.address.testutil.TypicalAccount.SIMUN;
@@ -19,6 +20,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.XmlUtil;
 import seedu.address.model.account.Account;
 import seedu.address.model.account.AccountList;
+import seedu.address.model.account.Role;
 import seedu.address.testutil.TypicalAccount;
 
 public class XmlSerializableAccountListTest {
@@ -35,8 +37,14 @@ public class XmlSerializableAccountListTest {
         XmlSerializableAccountList dataFromFile = XmlUtil.getDataFromFile(TYPICAL_ACCOUNT_FILE,
                 XmlSerializableAccountList.class);
         AccountList accountListFromFile = dataFromFile.toModelType();
-        AccountList typicalAccountAccountList = TypicalAccount.getTypicalAccountList();
-        assertEquals(accountListFromFile, typicalAccountAccountList);
+        AccountList typicalAccountAccountList = new AccountList();
+        typicalAccountAccountList.addAccount(new Account("rootUser", "rootPassword", Role.SUPER_USER));
+        typicalAccountAccountList.addAccount(new Account("simun", "@myPassword", Role.SUPER_USER));
+        typicalAccountAccountList.addAccount(new Account("whiterose", "@myPassword", Role.SUPER_USER));
+
+        for (Account account : typicalAccountAccountList.getList()) {
+            assertTrue(accountListFromFile.hasUsernameAndPassword(account.getUserName(), account.getPassword()));
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PasswordUtil.java
+++ b/src/test/java/seedu/address/testutil/PasswordUtil.java
@@ -1,0 +1,18 @@
+package seedu.address.testutil;
+
+import static org.junit.Assert.assertTrue;
+
+import seedu.address.logic.security.PasswordAuthentication;
+
+public class PasswordUtil {
+    /**
+     * Assert that the given plainTextPassword corresponds to the hashedpassword supplied.
+     * @param plainTextPassword The password in plaintext
+     * @param hashedPassword A hashed string
+     */
+    public static void assertPasswordCorrect(String plainTextPassword, String hashedPassword) {
+        PasswordAuthentication passwordAuthentication = new PasswordAuthentication();
+        assertTrue(passwordAuthentication.authenticate(plainTextPassword.toCharArray(), hashedPassword));
+    }
+}
+

--- a/src/test/java/seedu/address/testutil/PasswordUtil.java
+++ b/src/test/java/seedu/address/testutil/PasswordUtil.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertTrue;
 
 import seedu.address.logic.security.PasswordAuthentication;
 
+/**
+ * A utility class for password related methods
+ */
 public class PasswordUtil {
     /**
      * Assert that the given plainTextPassword corresponds to the hashedpassword supplied.

--- a/src/test/java/seedu/address/testutil/TypicalAccount.java
+++ b/src/test/java/seedu/address/testutil/TypicalAccount.java
@@ -25,6 +25,7 @@ public class TypicalAccount {
         for (Account account : getTypicalAccount()) {
             accountList.addAccount(account);
         }
+
         return accountList;
     }
 


### PR DESCRIPTION
To prevent storing of password in plaintext, we use salt and hash to store a hashed version of the user password.