### PR TITLE
Fix the bug where logging out and logging in can undo states

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -407,7 +407,7 @@ It only shows you the clients whose budgets can afford the service of the partic
 
 === Listing entered commands: `history`
 
-Lists all the commands that you have entered in reverse chronological order for this particular session. Histories are deleted upon exiting the app.
+Lists all the commands that you have entered in reverse chronological order for this particular session. Histories are deleted upon logging out or exiting the app. By default, command containing the word `login` will not be save to history. This is to protect user password from being revealed. The command `logout` will also not be save to history as the session has ended due to logging out.
 
 Format: `history`
 
@@ -417,7 +417,7 @@ Pressing the kbd:[&uarr;] and kbd:[&darr;] arrows will display the previous and 
 // tag::undoredo[]
 === Undo the previous command: `undo`
 
-Undo the commands that you have entered in chronological order for this particular session. Once you exit the application, you cannot `undo` a command from the last session.
+Undo the commands that you have entered in chronological order for this particular session. Once you logout or exit the application, you cannot `undo` a command from the last session.
 
 Format: `undo`
 
@@ -429,7 +429,7 @@ The application will show either the client list or vendor list corresponding to
 
 === Redo the commands undone: `redo`
 
-Redo the commands that you have undone by undo in chronological order for this particular session. Once you exit the application, you cannot `redo` a command from the last session.
+Redo the commands that you have undone by undo in chronological order for this particular session. Once you logout or exit the application, you cannot `redo` a command from the last session.
 
 Format: `redo`
 

--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -34,6 +34,13 @@ public class CommandHistory {
         return new LinkedList<>(userInputHistory);
     }
 
+    /**
+     * Delete the entire command history.
+     */
+    public void clear() {
+        userInputHistory.clear();
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -7,6 +7,8 @@ import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.LoginCommand;
+import seedu.address.logic.commands.LogoutCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.exceptions.LackOfPrivilegeException;
 import seedu.address.logic.parser.AddressBookParser;
@@ -43,7 +45,11 @@ public class LogicManager extends ComponentManager implements Logic {
             }
             return command.execute(model, history);
         } finally {
-            history.add(commandText);
+            // do not add to history for logging in as it reveals user password.
+            // do not add to history if logging out, as it is terminating a session.
+            if (!commandText.contains(LoginCommand.COMMAND_WORD) && !commandText.equals(LogoutCommand.COMMAND_WORD)) {
+                history.add(commandText);
+            }
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogoutCommand.java
@@ -4,7 +4,6 @@ import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.ui.LogoutRequestEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 
 /**
  * Log the user out of the application.

--- a/src/main/java/seedu/address/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogoutCommand.java
@@ -4,6 +4,7 @@ import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.ui.LogoutRequestEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
 
 /**
  * Log the user out of the application.
@@ -19,6 +20,7 @@ public class LogoutCommand extends Command {
     public CommandResult execute(Model model, CommandHistory history) {
         model.commitUserLoggedOutSuccessfully();
         EventsCenter.getInstance().post(new LogoutRequestEvent());
+        history.clear();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -174,6 +174,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void commitUserLoggedOutSuccessfully() {
         userAccount = null;
+        versionedAddressBook.clearState();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -20,6 +20,16 @@ public class VersionedAddressBook extends AddressBook {
     }
 
     /**
+     * Remove all states in the addressBookStateList except the latest one
+     */
+    public void clearState() {
+        ReadOnlyAddressBook temp = addressBookStateList.get(addressBookStateList.size() - 1);
+        addressBookStateList.clear();
+        addressBookStateList.add(temp);
+        currentStatePointer = 0;
+    }
+
+    /**
      * Saves a copy of the current {@code AddressBook} state at the end of the state list.
      * Undone states are removed from the state list.
      */

--- a/src/test/java/seedu/address/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/logic/CommandHistoryTest.java
@@ -37,6 +37,20 @@ public class CommandHistoryTest {
     }
 
     @Test
+    public void clear() {
+        final String validCommand = "clear";
+        final String invalidCommand = "adds Bob";
+
+        history.add(validCommand);
+        history.add(invalidCommand);
+        assertFalse(history.getHistory().size() == 0);
+        assertEquals(Arrays.asList(validCommand, invalidCommand), history.getHistory());
+
+        history.clear();
+        assertTrue(history.getHistory().size() == 0);
+    }
+
+    @Test
     public void equals() {
         final CommandHistory commandHistoryWithA = new CommandHistory();
         commandHistoryWithA.add("a");

--- a/src/test/java/seedu/address/model/VersionedAddressBookTest.java
+++ b/src/test/java/seedu/address/model/VersionedAddressBookTest.java
@@ -60,6 +60,25 @@ public class VersionedAddressBookTest {
     }
 
     @Test
+    public void resetState_success() {
+        VersionedAddressBook versionedAddressBook = prepareAddressBookList(
+                emptyAddressBook, addressBookWithAmy, addressBookWithBob);
+
+        versionedAddressBook.commit();
+        assertAddressBookListStatus(versionedAddressBook,
+                Arrays.asList(emptyAddressBook, addressBookWithAmy, addressBookWithBob),
+                addressBookWithBob,
+                Collections.emptyList());
+
+        versionedAddressBook.clearState();
+        versionedAddressBook.commit();
+        assertAddressBookListStatus(versionedAddressBook,
+                Arrays.asList(addressBookWithBob),
+                addressBookWithBob,
+                Collections.emptyList());
+    }
+
+    @Test
     public void canUndo_multipleAddressBookPointerAtEndOfStateList_returnsTrue() {
         VersionedAddressBook versionedAddressBook = prepareAddressBookList(
                 emptyAddressBook, addressBookWithAmy, addressBookWithBob);


### PR DESCRIPTION
Fix #317 

Now, after logging out, the history is cleared.
Also, commands containing the word `login` will not be save to history. This is to prevent leaking user typed password. The command `logout` will also not be save to history since the session is ending and user is logging out.